### PR TITLE
chore: adopt mise for hugo version management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,19 +4,12 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  HUGO_VERSION: 0.161.1
-
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Setup Hugo
-        run: |
-          wget -qO hugo.tar.gz "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
-          tar -xzf hugo.tar.gz hugo
-          sudo mv hugo /usr/local/bin/
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Build
         run: hugo --minify
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,19 +10,12 @@ permissions:
   pages: write
   id-token: write
 
-env:
-  HUGO_VERSION: 0.161.1
-
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Setup Hugo
-        run: |
-          wget -qO hugo.tar.gz "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
-          tar -xzf hugo.tar.gz hugo
-          sudo mv hugo /usr/local/bin/
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Build
         run: hugo --minify
       - name: Upload artifact

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,11 +5,12 @@ This file provides guidance to Claude Code when working with this repository.
 ## Commands
 
 ```bash
+mise install       # install Hugo at the version pinned in mise.toml
 hugo server        # live-reload dev server at http://localhost:1313
 hugo --minify      # production build → public/
 ```
 
-No npm, no build step. Hugo is a self-contained binary.
+No npm, no build step. Hugo is a self-contained binary, managed via `mise`.
 
 ## Architecture
 
@@ -86,7 +87,7 @@ CI runs on pull requests via `.github/workflows/ci.yml` — three concurrent job
 
 ### Hugo version
 
-`HUGO_VERSION` is defined as a top-level `env` var in **both** `deploy.yml` and `ci.yml`. Bump it in both files when upgrading Hugo.
+The Hugo version is pinned in `mise.toml` at the repo root — single source of truth for both local dev (`mise install`) and CI (via `jdx/mise-action`). Renovate raises bump PRs against `mise.toml` automatically.
 
 ### GitHub Actions convention
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,5 +1,5 @@
 baseURL = "https://tobybessant.co.uk/"
-languageCode = "en-gb"
+locale = "en-gb"
 title = "Toby Bessant | Principal Engineer, London"
 
 disableKinds = ["taxonomy", "term"]

--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -1,4 +1,4 @@
-{{ $a := site.Data.about }}
+{{ $a := hugo.Data.about }}
 {{ if $a.enabled }}
 <section class="section">
   <span id="about" class="section-anchor"></span>

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -1,4 +1,4 @@
-{{ $c := site.Data.contact }}
+{{ $c := hugo.Data.contact }}
 {{ if $c.enabled }}
 <section class="section">
   <span id="contact" class="section-anchor"></span>

--- a/layouts/partials/experience.html
+++ b/layouts/partials/experience.html
@@ -1,4 +1,4 @@
-{{ $e := site.Data.experience }}
+{{ $e := hugo.Data.experience }}
 {{ if $e.enabled }}
 <section class="section">
   <span id="experience" class="section-anchor"></span>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,12 +5,12 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,600;1,9..40,400&family=Vollkorn:ital,wght@0,400..900;1,400..900&display=swap" rel="stylesheet" />
-  {{ $css := resources.Get "css/main.css" | minify | fingerprint }}
+  {{ $css := resources.Get "css/main.css" | css.Build (dict "minify" true) | fingerprint }}
   <link rel="stylesheet" href="{{ $css.RelPermalink }}" />
   <script src="/js/theme-toggle.js"></script>
   <script defer src="/js/email-reveal.js"></script>
   {{ $ogImg := (resources.Get "img/profile.png").Resize "800x webp" }}
-  {{ $desc := site.Data.about.content | markdownify | plainify | htmlUnescape | chomp | truncate 160 }}
+  {{ $desc := hugo.Data.about.content | markdownify | plainify | htmlUnescape | chomp | truncate 160 }}
   <meta property="og:type" content="website" />
   <meta property="og:url" content="{{ site.BaseURL }}" />
   <meta property="og:title" content="{{ site.Title }}" />

--- a/layouts/partials/hero.html
+++ b/layouts/partials/hero.html
@@ -1,4 +1,4 @@
-{{ $l := site.Data.landing }}
+{{ $l := hugo.Data.landing }}
 
 <div class="hero">
   <div class="profile-img">

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,7 +1,7 @@
-{{ $about := site.Data.about }}
-{{ $experience := site.Data.experience }}
-{{ $projects := site.Data.projects }}
-{{ $contact := site.Data.contact }}
+{{ $about := hugo.Data.about }}
+{{ $experience := hugo.Data.experience }}
+{{ $projects := hugo.Data.projects }}
+{{ $contact := hugo.Data.contact }}
 
 <nav class="nav">
   <div class="nav-container">

--- a/layouts/partials/projects.html
+++ b/layouts/partials/projects.html
@@ -1,4 +1,4 @@
-{{ $p := site.Data.projects }}
+{{ $p := hugo.Data.projects }}
 {{ if $p.enabled }}
 <section class="section">
   <span id="projects" class="section-anchor"></span>

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+"aqua:gohugoio/hugo/hugo-extended" = "0.161.1"

--- a/renovate.json
+++ b/renovate.json
@@ -5,25 +5,11 @@
   ],
   "dependencyDashboard": false,
   "minimumReleaseAge": "7 days",
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/^\\.github/workflows/.*\\.yml$/"
-      ],
-      "matchStrings": [
-        "HUGO_VERSION: (?<currentValue>[\\d.]+)"
-      ],
-      "depNameTemplate": "gohugoio/hugo",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.*)$"
-    }
-  ],
   "packageRules": [
     {
       "matchManagers": [
         "github-actions",
-        "custom.regex"
+        "mise"
       ],
       "matchUpdateTypes": [
         "major",


### PR DESCRIPTION
## Summary

- Move Hugo version pinning to **`mise.toml`** as a single source of truth (was duplicated as `HUGO_VERSION` env in both `ci.yml` and `deploy.yml`). Local dev and CI now install via the same pinned version, with checksum verification courtesy of the `aqua` backend.
- Clear out two Hugo deprecations surfaced during a v0.146 → v0.161.1 release-notes review: `languageCode` → `locale` in `hugo.toml`, and `site.Data` → `hugo.Data` across template partials.
- Switch the CSS asset pipeline to `css.Build` (introduced in Hugo v0.158), keeping minification + fingerprinting behaviour identical.

## Test plan

- [x] `mise install` pulls Hugo 0.161.1 with checksum verification (verified locally)
- [x] `hugo --minify --gc` builds with no deprecation warnings (verified locally)
- [x] CSS output is still minified and fingerprinted (`/css/main.<hash>.css`)
- [x] HTML output is still minified (attribute quotes stripped, etc.)
- [x] CI passes on this PR
- [ ] Deployed site renders identically after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)