### PR TITLE
chore: add mise note to protov project entry

### DIFF
--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -26,6 +26,9 @@ entries:
       A lightweight version manager for Protocol Buffers (protoc). Written as a single-file
       Python CLI with zero dependencies, it handles downloading, installing, and switching
       between protoc versions with an interactive picker.
+
+
+      *Built before I knew about [mise](https://github.com/jdx/mise) — you should just use mise.*
     tags: []
     links:
       - featherIconKey: "github"

--- a/layouts/partials/projects.html
+++ b/layouts/partials/projects.html
@@ -17,7 +17,7 @@
         {{ end }}
       </div>
     </div>
-    <div class="prose">{{ .description | markdownify }}</div>
+    <div class="prose">{{ $.RenderString .description }}</div>
     <div class="tags">
       {{ range .tags }}
         <span>{{ . }}</span>


### PR DESCRIPTION
## Summary
- Adds an italicised footnote to the protov project description: *Built before I knew about [mise](https://github.com/jdx/mise) — you should just use mise.* The first "mise" links to the upstream repo and opens in a new tab via the existing render-link hook.
- Switches the projects partial from \`markdownify\` to \`\$.RenderString\` so project descriptions now go through the same render-link hook as \`about.html\` (target=_blank + rel=noopener for external links).

## Test plan
- [x] \`hugo server\` renders the new paragraph as a separate italic line, with the mise link opening in a new tab.
- [x] CI passes (build + typos + yamllint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)