### PR TITLE
feat: lift experience section hierarchy with accent colours

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -403,6 +403,7 @@ a {
   font-family: var(--font-body);
   font-weight: 700;
   font-size: 1.3rem;
+  color: var(--color-h2);
 }
 
 .xp-role {
@@ -432,7 +433,7 @@ a {
 .xp-title {
   font-family: var(--font-ui);
   font-size: 1.2rem;
-  opacity: 0.8;
+  color: var(--color-subheading);
 }
 
 /* =====================


### PR DESCRIPTION
## Summary
- \`.xp-company\` now renders in \`--color-h2\` (honey), giving each entry a warm anchor and mirroring the hero's sage-h1 / honey-h2 pattern. Fixes the "everything blends to grey" feel of the experience section in dark mode.
- \`.xp-title\` switches from \`opacity: 0.8\` to \`color: var(--color-subheading)\`, in line with the comment already in the file noting that opacity dimming bleeds the bg through on dark surfaces and kills contrast — explicit colour values do the hierarchy work instead.

## Test plan
- [x] \`hugo server\` renders cleanly; CSS pipeline picks up the changes.
- [x] CI passes (build + typos + yamllint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)